### PR TITLE
Suggestions for improvement of  "add resize action"

### DIFF
--- a/troposphere/static/js/actions/instance/resize.js
+++ b/troposphere/static/js/actions/instance/resize.js
@@ -53,7 +53,7 @@ export default {
             });
             Utils.dispatch(InstanceConstants.POLL_INSTANCE_WITH_DELAY, {
                 instance: instance,
-                delay: 15*1000
+                delay: 5*1000
             });
         });
     }

--- a/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.jsx
@@ -65,7 +65,7 @@ export default React.createClass({
                     <Button style={style}
                         key="Resize"
                         icon="repeat"
-                        tooltip-"Resize"
+                        tooltip="Resize"
                         onClick={this.onResize}
                         isVisible={true} />
                 );

--- a/troposphere/static/js/components/projects/detail/resources/tableData/instance/Status.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/tableData/instance/Status.jsx
@@ -16,7 +16,7 @@ export default React.createClass({
         var activity = instanceState.get("activity");
         var lightStatus;
 
-        if (activity || status == "build") {
+        if (activity || status == "build" || status == "verify_resize") {
             lightStatus = "transition";
         } else if (status == "active") {
             lightStatus = "active";

--- a/troposphere/static/js/models/Instance.js
+++ b/troposphere/static/js/models/Instance.js
@@ -43,6 +43,7 @@ export default Backbone.Model.extend({
             var statusSplit = attrs.status.split(" - ");
             this.set("ip_address", attrs.ip_address);
             this.set("status", attrs.status);
+            this.set("size", attrs.size);
             this.set("state", new InstanceState({
                 status_raw: attrs.status,
                 status: statusSplit[0],

--- a/troposphere/static/js/models/Instance.js
+++ b/troposphere/static/js/models/Instance.js
@@ -121,7 +121,7 @@ export default Backbone.Model.extend({
     },
 
     is_active: function() {
-        var states = ["active", "running", "verify_resize"];
+        var states = ["active", "running"];
         return _.contains(states, this.get("status"));
     },
 
@@ -139,10 +139,12 @@ export default Backbone.Model.extend({
             "pending",
             "suspended - resuming",
             "active - suspending",
+            "active - resizing",
             "resize - resize_prep",
             "resize - resize_migrating",
             "resize - resize_migrated",
             "resize - resize_finish",
+            "verify_resize",
             "active - networking",
             "active - deploying",
             "active - initializing",

--- a/troposphere/static/js/models/InstanceState.js
+++ b/troposphere/static/js/models/InstanceState.js
@@ -33,10 +33,7 @@ var InstanceState = Backbone.Model.extend({
     getPercentComplete: function() {
         var status = this.get("status");
         var activity = this.get("activity");
-        var percentComplete = 100;
-        if (status && activity) {
-            percentComplete = get_percent_complete(status, activity);
-        }
+        var percentComplete = get_percent_complete(status, activity);
         return percentComplete;
     },
 
@@ -64,6 +61,7 @@ var get_percent_complete = function(state, activity) {
                 "deleting": 50,
             },
             "active": {
+                "resizing" : 25,
                 "powering-off": 50,
                 "image_uploading": 50,
                 "deleting": 50,
@@ -79,10 +77,15 @@ var get_percent_complete = function(state, activity) {
             "reboot": {
                 "rebooting": 50
             },
+            "verify_resize": {
+                "": 75,
+            },
             "resize": {
-                "resizing" : 10,
-                "resizing_confirming": 50,
-                "resizing_verifying" : 80
+                "" : 25,
+                "resizing" : 25,
+                "resize_finish" : 50,
+                "resizing_confirming": 65,
+                "resizing_verifying" : 75
             },
             "shutoff": {
                 "powering-on": 50
@@ -93,6 +96,9 @@ var get_percent_complete = function(state, activity) {
             "error": {}
         };
 
+    if (!state) {
+        state = "error";
+    }
     lookup = states[state];
 
     if (!lookup) {


### PR DESCRIPTION
## Description

- Drop delay from 15s to 5s so user can observe changes.
- Fix `tooltip-"Resize"` should be `tooltip="resize"`
- remove `verify_resize` from the 'final state' list.
- Include a progress-bar for the various known resize states.
- Allow update of 'size' during API v1 Polling (Requires the Atmosphere suggestions PR to work as expected).