### PR TITLE
Include support for Revert and Confirm resize

### DIFF
--- a/troposphere/static/js/actions/InstanceActions.js
+++ b/troposphere/static/js/actions/InstanceActions.js
@@ -26,5 +26,7 @@ export default {
     update: IUpdate.update,
     report: IReport.report,
     requestImage: IRequest.requestImage,
-    resize: IResize.resize
+    resize: IResize.resize,
+    confirmResize: IResize.confirmResize,
+    revertResize: IResize.revertResize
 };

--- a/troposphere/static/js/actions/instance/resize.js
+++ b/troposphere/static/js/actions/instance/resize.js
@@ -5,6 +5,100 @@ import InstanceActionRequest from "models/InstanceActionRequest";
 
 export default {
 
+    revertResize: function(params) {
+        if (!params.instance)
+            throw new Error("Missing Instance");
+        var instance = params.instance,
+            instanceState = new InstanceState({
+                status_raw: "revert_resize - resize_reverting",
+                status: "revert_resize",
+                activity: "resize_reverting"
+            }),
+            originalState = instance.get("state"),
+            actionRequest = new InstanceActionRequest({
+                instance: instance
+            });
+
+        instance.set({
+            state: instanceState
+        });
+        Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+            instance: instance
+        });
+
+        actionRequest.save(null, {
+            attrs: {
+                action: "revert_resize",
+            }
+        }).done(function() {
+            instance.set({
+                state: instanceState
+            });
+        }).fail(function(response) {
+            instance.set({
+                state: originalState
+            });
+            Utils.displayError({
+                title: "Failed to execute 'revert_resize'",
+                response: response
+            });
+        }).always(function() {
+            Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+                instance: instance
+            });
+            Utils.dispatch(InstanceConstants.POLL_INSTANCE_WITH_DELAY, {
+                instance: instance,
+                delay: 5*1000
+            });
+        });
+    },
+    confirmResize: function(params) {
+        if (!params.instance)
+            throw new Error("Missing Instance");
+        var instance = params.instance,
+            instanceState = new InstanceState({
+                status_raw: "verify_resize - confirm_resize",
+                status: "verify_resize",
+                activity: "confirm_resize"
+            }),
+            originalState = instance.get("state"),
+            actionRequest = new InstanceActionRequest({
+                instance: instance
+            });
+
+        instance.set({
+            state: instanceState
+        });
+        Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+            instance: instance
+        });
+
+        actionRequest.save(null, {
+            attrs: {
+                action: "confirm_resize",
+            }
+        }).done(function() {
+            instance.set({
+                state: instanceState
+            });
+        }).fail(function(response) {
+            instance.set({
+                state: originalState
+            });
+            Utils.displayError({
+                title: "Failed to execute 'confirm_resize'",
+                response: response
+            });
+        }).always(function() {
+            Utils.dispatch(InstanceConstants.UPDATE_INSTANCE, {
+                instance: instance
+            });
+            Utils.dispatch(InstanceConstants.POLL_INSTANCE_WITH_DELAY, {
+                instance: instance,
+                delay: 5*1000
+            });
+        });
+    },
     resize: function(params) {
         if (!params.instance)
             throw new Error("Missing Instance");

--- a/troposphere/static/js/components/modals/instance/InstanceResizeModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceResizeModal.jsx
@@ -35,7 +35,9 @@ export default React.createClass({
     //
 
     propTypes: {
-        project: React.PropTypes.instanceOf(Backbone.Model),
+        instance: React.PropTypes.instanceOf(Backbone.Model),
+        size: React.PropTypes.instanceOf(Backbone.Model),
+        type: React.PropTypes.string.isRequired,
         onConfirm: React.PropTypes.func.isRequired,
     },
 
@@ -143,6 +145,45 @@ export default React.createClass({
 
 
     renderBody: function() {
+        if(this.props.type == 'confirm') {
+            return this.renderConfirmResizeBody();
+        } else if (this.props.type == "revert") {
+            return this.renderRevertResizeBody();
+        } else {
+            return this.renderStartResizeBody();
+        }
+    },
+    renderOkText: function() {
+        if(this.props.type == "confirm") {
+            return "Confirm Resize"
+        } else if (this.props.type == "revert") {
+            return "Revert Resize"
+        } else {
+            return "Resize"
+        }
+    },
+    renderRevertResizeBody: function() {
+        return (
+        <div>
+            <p>
+                {"Would you like to revert this instance to its original size?"}
+            </p>
+        </div>);
+    },
+
+    renderConfirmResizeBody: function() {
+        return (
+        <div>
+            <p>
+                {"Would you like to confirm this instance to its original size?"}
+            </p>
+            <p>
+                {"NOTE: This operation cannot be undone! Be sure that your instance works as expected prior to confirming the resize."}
+            </p>
+        </div>);
+    },
+
+    renderStartResizeBody: function() {
         let provider = this.state.provider;
         let providerSize = this.state.providerSize;
 
@@ -183,7 +224,6 @@ export default React.createClass({
         </form>
         );
     },
-
     render: function() {
         return (
         <div className="modal fade">
@@ -201,7 +241,7 @@ export default React.createClass({
                             Cancel
                         </button>
                         <button type="button" className="btn btn-primary" onClick={this.confirmResize}>
-                            Resize
+                            { this.renderOkText() }
                         </button>
                     </div>
                 </div>

--- a/troposphere/static/js/components/modals/instance/InstanceResizeModal.jsx
+++ b/troposphere/static/js/components/modals/instance/InstanceResizeModal.jsx
@@ -3,6 +3,7 @@ import BootstrapModalMixin from "components/mixins/BootstrapModalMixin";
 import stores from "stores";
 import ResourceGraphs from "components/modals/instance/launch/components/ResourceGraphs";
 import SelectMenu from "components/common/ui/SelectMenu";
+import Glyphicon from "components/common/Glyphicon";
 import globals from "globals";
 
 export default React.createClass({
@@ -142,8 +143,6 @@ export default React.createClass({
 
         return `${ name } (CPU: ${ cpu }, Mem: ${ memory } GB, ${ diskStr })`;
     },
-
-
     renderBody: function() {
         if(this.props.type == 'confirm') {
             return this.renderConfirmResizeBody();
@@ -206,6 +205,12 @@ export default React.createClass({
         return (
         <form>
             <div className="form-group">
+                <p className="alert alert-danger">
+                    <Glyphicon name="warning-sign" />
+                    {" "}
+                    <strong>WARNING</strong>
+                    {" Do not resize your instance to a smaller size, as this can cause unexpected instance failure!"}
+                </p>
                 <label htmlFor="instanceSize">
                     Instance Size
                 </label>

--- a/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.jsx
+++ b/troposphere/static/js/components/projects/detail/resources/InstanceActionButtons.jsx
@@ -51,6 +51,7 @@ export default React.createClass({
             style = {
                 marginRight: "10px"
             };
+        debugger;
         if (!this.props.multipleSelected && instance.get("state").isInFinalState()) {
             if (status === "active") {
                 linksArray.push(

--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
@@ -64,6 +64,12 @@ export default React.createClass({
                 onClick: this.onReboot
             },
             {
+                key: "Resize",
+                label: "Resize",
+                icon: "resize-full",
+                onClick: this.onResize
+            },
+            {
                 key: "Redeploy",
                 label: "Redeploy",
                 icon: "repeat",
@@ -206,15 +212,15 @@ export default React.createClass({
         ];
 
         if (webDesktopCapable && featureFlags.WEB_DESKTOP) {
-            linksArray.push({
+            links.push({
                 label: "Open Web Desktop",
                 icon: "sound-stereo",
                 onClick: this.onWebDesktop.bind(
                     this,
-                    ip_address,
+                    ipAddress,
                     this.props.instance),
                 openInNewWindow: true,
-                isDisabled: webLinksDisabled
+                isDisabled: disableWebLinks
             });
         }
 

--- a/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
+++ b/troposphere/static/js/components/projects/resources/instance/details/actions/InstanceActionsAndLinks.jsx
@@ -64,6 +64,18 @@ export default React.createClass({
                 onClick: this.onReboot
             },
             {
+                key: "Confirm Resize",
+                label: "Confirm Resize",
+                icon: "resize-full",
+                onClick: this.onConfirmResize
+            },
+            {
+                key: "Revert Resize",
+                label: "Revert Resize",
+                icon: "resize-full",
+                onClick: this.onRevertResize
+            },
+            {
                 key: "Resize",
                 label: "Resize",
                 icon: "resize-full",
@@ -115,8 +127,16 @@ export default React.createClass({
         modals.InstanceModals.start(this.props.instance);
     },
 
+    onConfirmResize: function() {
+        modals.InstanceModals.resize(this.props.instance, 'confirm');
+    },
+
+    onRevertResize: function() {
+        modals.InstanceModals.resize(this.props.instance, 'revert');
+    },
+
     onResize: function() {
-        modals.InstanceModals.resize(this.props.instance);
+        modals.InstanceModals.resize(this.props.instance, 'resize');
     },
 
     onSuspend: function() {

--- a/troposphere/static/js/modals/instance/resize.js
+++ b/troposphere/static/js/modals/instance/resize.js
@@ -6,7 +6,8 @@ import actions from "actions";
 export default {
 
     resize: function(instance) {
-        ModalHelpers.renderModal(InstanceResizeModal, null, function(resize_size) {
+        let props = {instance: instance};
+        ModalHelpers.renderModal(InstanceResizeModal, props, function(resize_size) {
             actions.InstanceActions.resize({
                 instance: instance,
                 resize_size: resize_size

--- a/troposphere/static/js/modals/instance/resize.js
+++ b/troposphere/static/js/modals/instance/resize.js
@@ -5,13 +5,32 @@ import actions from "actions";
 
 export default {
 
-    resize: function(instance) {
-        let props = {instance: instance};
+    resize: function(instance, resize_type) {
+        /**
+         * 3 types of resize
+         * null/resize -- Start resize instance process
+         * revert - Revert a resized instance
+         * confirm - Confirm a resized instance
+         */
+        let props = {
+            instance: instance,
+            type: resize_type
+        };
         ModalHelpers.renderModal(InstanceResizeModal, props, function(resize_size) {
-            actions.InstanceActions.resize({
-                instance: instance,
-                resize_size: resize_size
-            });
+            if (resize_type == 'revert') {
+                actions.InstanceActions.revertResize({
+                    instance: instance
+                });
+            } else if (resize_type == 'confirm') {
+                actions.InstanceActions.confirmResize({
+                    instance: instance
+                });
+            } else {
+                actions.InstanceActions.resize({
+                    instance: instance,
+                    resize_size: resize_size
+                });
+            }
         });
     }
 

--- a/troposphere/static/js/models/Instance.js
+++ b/troposphere/static/js/models/Instance.js
@@ -142,15 +142,19 @@ export default Backbone.Model.extend({
             "active - suspending",
             "active - resizing",
             "resize - resize_prep",
+            "resize - resize_migrate",
             "resize - resize_migrating",
             "resize - resize_migrated",
+            "resize - resize_prep",
             "resize - resize_finish",
+            "resize - revert_resize",
+            "resize - confirm_resize",
             "verify_resize",
             "active - networking",
             "active - deploying",
             "active - initializing",
-            "hard_reboot - rebooting_hard",
-            "revert_resize - resize_reverting"
+            "active - confirm_resize",
+            "hard_reboot - rebooting_hard"
         ];
         return _.contains(states, this.get("status"));
     },

--- a/troposphere/static/js/models/InstanceState.js
+++ b/troposphere/static/js/models/InstanceState.js
@@ -77,15 +77,24 @@ var get_percent_complete = function(state, activity) {
             "reboot": {
                 "rebooting": 50
             },
+            "revert_resize": {
+                "": 35,
+                "resize_reverting": 75,
+            },
             "verify_resize": {
-                "": 75,
+                "": 80,
+                "confirm_resize": 95,
             },
             "resize": {
                 "" : 25,
                 "resizing" : 25,
-                "resize_finish" : 50,
-                "resizing_confirming": 65,
-                "resizing_verifying" : 75
+                "resize_migrate" : 35,
+                "resize_migrating": 35,
+                "resize_migrated": 35,
+                "revert_resize": 35,
+                "confirm_resize": 35,
+                "resize_confirming": 35,
+                "resize_finish" : 75,
             },
             "shutoff": {
                 "powering-on": 50


### PR DESCRIPTION
While automated resizes may work for some sites, full support for resize includes handling "confirm" and "revert".

Example Screenshots:
![1-active-to-resize](https://cloud.githubusercontent.com/assets/2889930/25205954/2361fe9a-251a-11e7-9b0c-5255369b59dd.gif)
![2-resize-to-confirm](https://cloud.githubusercontent.com/assets/2889930/25205971/2db637da-251a-11e7-90f9-240b1d3b8524.gif)
![2-resize-to-revert](https://cloud.githubusercontent.com/assets/2889930/25205960/2a513e5a-251a-11e7-9997-a0029db5c385.gif)

